### PR TITLE
Add command history logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+history.list

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Run `cli.py` without arguments to see usage instructions. Use the `--test` optio
 python3 cli.py --test
 ```
 
+Every invocation of `cli.py` is appended to `history.list` in the
+repository root so you can review past commands.
+

--- a/cli.py
+++ b/cli.py
@@ -45,6 +45,14 @@ def scan_env():
 
 def main(argv=None):
     argv = argv or sys.argv[1:]
+    # Record the executed command for simple history tracking.
+    try:
+        command = " ".join([sys.executable] + sys.argv)
+        with open("history.list", "a") as history:
+            history.write(command + "\n")
+    except OSError:
+        # Ignore failures since history tracking should not break the tool.
+        pass
     if not argv or argv[0] in {"-h", "--help"}:
         print_usage()
         return 0


### PR DESCRIPTION
## Summary
- log the exact command to `history.list` on each invocation
- document the new history file in README
- ignore `history.list` and `__pycache__/`

## Testing
- `python3 cli.py --test`
- `python3 -m py_compile cli.py`
