### PR TITLE
Add command history saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Run `cli.py` without arguments to see usage instructions. Use the `--test` optio
 python3 cli.py --test
 ```
 
+Each invocation of the CLI is appended to `~/.codextest_history` so you can review
+the commands you've run.
+

--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,25 @@ import os
 import sys
 from pathlib import Path
 
-USAGE = """Usage: cli.py [--test]\n\nOptions:\n  --test       Scan environment for postgres DB connections.\n  -h, --help   Show this help message.\n"""
+HISTORY_FILE = Path.home() / ".codextest_history"
+
+
+def save_history(args):
+    """Append the given arguments to the history file."""
+    try:
+        with open(HISTORY_FILE, "a", encoding="utf-8") as fh:
+            fh.write(" ".join(args) + "\n")
+    except OSError:
+        # Failing to write history should not prevent the CLI from working
+        pass
+
+USAGE = (
+    "Usage: cli.py [--test]\n\n"
+    "Options:\n"
+    "  --test       Scan environment for postgres DB connections.\n"
+    "  -h, --help   Show this help message.\n\n"
+    "Command history is saved to ~/.codextest_history."
+)
 
 def print_usage():
     print(USAGE.strip())
@@ -45,6 +63,7 @@ def scan_env():
 
 def main(argv=None):
     argv = argv or sys.argv[1:]
+    save_history(argv)
     if not argv or argv[0] in {"-h", "--help"}:
         print_usage()
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,8 @@ import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
 import sys
+import tempfile
+from pathlib import Path
 
 import cli
 
@@ -66,6 +68,18 @@ class TestCLI(unittest.TestCase):
                 cli.scan_env()
         output = buf.getvalue()
         self.assertIn("No postgres connection info found.", output)
+
+    def test_history_file_written(self):
+        """GIVEN a call to main
+        WHEN it is executed
+        THEN the invocation should be appended to the history file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = Path(tmpdir) / ".codextest_history"
+            with patch.object(cli, "HISTORY_FILE", history):
+                cli.main(["--test"])
+            self.assertTrue(history.exists())
+            content = history.read_text().strip()
+            self.assertEqual(content, "--test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- store cli invocations in ~/.codextest_history
- mention history in README
- test the new history feature

## Testing
- `python3 cli.py --test`
- `python3 -m unittest -q tests/test_cli.py`
